### PR TITLE
mdnPlugin: fix double space to work with line returns

### DIFF
--- a/src/plugins/mdn/mdnPlugin.js
+++ b/src/plugins/mdn/mdnPlugin.js
@@ -122,7 +122,7 @@ module.exports = async function mdnPlugin(msg) {
     .text()
     .trim()
     .replace(/^The /, '')
-    .replace(/  +/g, ' ');
+    .replace(/\s{2,}/g, ' ');
 
   msg.respondWithMention(
     `${isDeprecated ? 'DEPRECATED ' : ''}${description.slice(0, 350)}${


### PR DESCRIPTION
@ljharb better tested locally this time

```
> r=await s.get('https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys')
> $=cheerio.load(r.text)
> p=$('article p').first().text().trim().replace(/\s{2,}/g, ' ')
"The Object.keys() method returns an array of a given object's own enumerable property names, iterated in the same order that a normal loop would."
```