### PR TITLE
plugin !npm, separate link from version|date|descr with a space, inst…

### DIFF
--- a/src/plugins/npm/npmPlugin.js
+++ b/src/plugins/npm/npmPlugin.js
@@ -39,7 +39,9 @@ module.exports = async function npmPlugin(msg) {
               p.version,
               p.date && p.date.slice(0, 10),
               getDesc(p.description, 80),
-            ].join('|'),
+            ]
+              .join('|')
+              .replace('|', ' '),
           )
           .join(' ⸺ '),
       );
@@ -58,7 +60,9 @@ module.exports = async function npmPlugin(msg) {
           version,
           ((data['dist-tags'] && data.time[version]) || '').slice(0, 10),
           getDesc(data.description),
-        ].join('|'),
+        ]
+          .join('|')
+          .replace('|', ' '),
       );
     } catch (err) {
       msg.respondWithMention('Failed to look up package');

--- a/src/plugins/npm/npmPlugin.test.js
+++ b/src/plugins/npm/npmPlugin.test.js
@@ -13,9 +13,10 @@ async function testNpm(message) {
 it('works', async () => {
   const output = await testNpm('npm bootstrap');
 
-  expect(output.split('|')[0]).toEqual('npm.im/bootstrap');
-  expect(output.split('|')[1]).toMatch(/^\d+\.\d+\.\d+/);
-  expect(output.split('|')[2]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  const [beforeSpace, afterSpace] = output.split(' ');
+  expect(beforeSpace).toEqual('npm.im/bootstrap');
+  expect(afterSpace.split('|')[0]).toMatch(/^\d+\.\d+\.\d+/);
+  expect(afterSpace.split('|')[1]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 });
 
 it('works for searches', async () => {
@@ -24,7 +25,8 @@ it('works for searches', async () => {
   const results = output.split(' ⸺ ');
   expect(results.length).toBeGreaterThan(2);
 
-  expect(results[0].split('|')[0]).toEqual('npm.im/bootstrap');
-  expect(results[0].split('|')[1]).toMatch(/^\d+\.\d+\.\d+/);
-  expect(results[0].split('|')[2]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  const [beforeSpace, afterSpace] = results[0].split(' ');
+  expect(beforeSpace).toEqual('npm.im/bootstrap');
+  expect(afterSpace.split('|')[0]).toMatch(/^\d+\.\d+\.\d+/);
+  expect(afterSpace.split('|')[1]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 });


### PR DESCRIPTION
…ead of |

oh, is this a bad commit message?

the other thing, prettier says:
/home/silly/www/dev/jellobot/src/plugins/npm/npmPlugin.test.js                                                                                       
  8:19  error  Delete `·`  prettier/prettier                                                                                                         
when there is no such char in the file, so weird...