### PR TITLE
[plugins/js-eval] add PID limit to docker command

### DIFF
--- a/src/plugins/js-eval/jsEvalPlugin.js
+++ b/src/plugins/js-eval/jsEvalPlugin.js
@@ -73,6 +73,7 @@ module.exports = async function jsEvalPlugin({
       '--rm',
       `--name=${name}`,
       `--net=none`,
+      `--pids-limit=50`,
       `-eJSEVAL_MODE=${mode}`,
       `-eJSEVAL_ENV=${envs[mode]}`,
       `-eJSEVAL_TIMEOUT=${timeoutMs}`,


### PR DESCRIPTION
This should reduce the impact of fork bombs on systems where `dockerd` doesn't already have appropriate resource limitations.