### PR TITLE
[plugins/js-eval] add deno environment

### DIFF
--- a/src/plugins/js-eval/Dockerfile
+++ b/src/plugins/js-eval/Dockerfile
@@ -5,22 +5,27 @@ ARG node_version=v19.0.0
 FROM debian:10-slim
 ARG node_version
 
-RUN apt-get update && apt-get install -y xz-utils ca-certificates curl --no-install-recommends
+RUN apt-get update && apt-get install -y xz-utils ca-certificates curl unzip --no-install-recommends
 RUN node_version=${node_version} \
   && curl -fsSLO --compressed "https://nodejs.org/download/release/$node_version/node-$node_version-linux-x64.tar.xz" \
   && tar -xJf "node-$node_version-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
 RUN node --version
 
+# install deno
+ENV DENO_INSTALL=/usr/local
+RUN curl -fsSL https://deno.land/x/install/install.sh -o install-deno.sh \
+  && sh install-deno.sh \
+  # && chown node:node /usr/local/bin/deno \
+  && rm install-deno.sh
+RUN deno --version
+
 # install shims, and acorn+nearley needed by engine262
 RUN npm i --prefix /run airbnb-js-shims@latest string.prototype.at@latest array.prototype.at@latest @bloomberg/record-tuple-polyfill@latest nearley@latest object.groupby@latest map.groupby@latest array.prototype.flat@latest array.prototype.flatmap@latest array.prototype.with@latest array.prototype.tosorted@latest array.prototype.toreversed@latest array.prototype.tospliced@latest set.prototype.union set.prototype.intersection set.prototype.difference set.prototype.symmetricdifference set.prototype.issubsetof set.prototype.issupersetof set.prototype.isdisjointfrom es-set es-map suppressed-error es-iterator-helpers arraybuffer.prototype.detached disposablestack promise.try math.sumprecise regexp.escape promise.prototype.finally
 RUN curl https://engine262.js.org/engine262/engine262.js -o /run/node_modules/engine262.js
 
-FROM debian:10-slim
-
-RUN useradd node && mkdir -p /home/node && chown -R node:node /home/node
+RUN useradd node && mkdir -p /home/node && chown -R node:node /home/node && chown node:node /usr/local/bin/deno
 WORKDIR /home/node
-COPY --from=0 /run /run
-COPY --from=0 /usr/local/bin/node /usr/local/bin/node
+
 COPY --chown=node run.js /run/
 USER node
 ENV NODE_ICU_DATA=/run/node_modules/full-icu

--- a/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
+++ b/src/plugins/js-eval/__tests__/jsEvalPlugin-test.js
@@ -152,4 +152,44 @@ describe('jsEvalPlugin', () => {
       expect(output3).toEqual(`(fail) TypeError: 2\n    at <anonymous>:1:22`);
     });
   });
+
+  describe('deno', () => {
+    it('works', async () => {
+      const output = await testEval('d> 2+2');
+      expect(output).toEqual('(okay) 4');
+    });
+
+    it('outputs console.warn', async () => {
+      const output = await testEval('d> console.warn("test")');
+      expect(output).toEqual(`(okay) test`);
+    });
+
+    it(`errors when it should`, async () => {
+      const output = await testEval('d> 2++2');
+      expect(output).toEqual(
+        `(fail) error: The module's source code could not be parsed: Expected ';', got 'numeric literal (2, 2)'. 2++2 ~`,
+      );
+
+      const output2 = await testEval('d> throw 2');
+      expect(output2).toEqual('(okay) 2');
+
+      const output3 = await testEval('d> throw new TypeError(2)');
+      expect(output3).toEqual('(okay) TypeError: 2');
+    });
+
+    it(`replies to user`, async () => {
+      const output = await testEval(`d>'ok'`, { mentionUser: 'jay' });
+      expect(output).toEqual(`jay, ok`);
+    });
+
+    it(`handles empty input`, async () => {
+      const output = await testEval(`d>  `);
+      expect(output).toEqual(`(okay) (empty)`);
+    });
+
+    it('correctly returns last expression', async () => {
+      const output = await testEval('d> let x:string = "hello world";x');
+      expect(output).toEqual('(okay) hello world');
+    });
+  });
 });

--- a/src/plugins/js-eval/jsEvalPlugin.js
+++ b/src/plugins/js-eval/jsEvalPlugin.js
@@ -12,6 +12,7 @@ const helpMsg = `n> node stable, b> babel, s> node vm.Script, m> node vm.SourceT
 const timeoutMs = 5000;
 const envs = {
   e: 'engine262',
+  d: 'deno',
   s: 'script',
   m: 'module',
   n: 'node-cjs',


### PR DESCRIPTION
This PR adds support for [deno](https://deno.com/) [eval](https://docs.deno.com/runtime/manual/tools/eval) using the `d>` prefix. 

Deno is a modern JavaScript runtime with builtin support for TypeScript, isomorphism with many standard Web APIs and [many more](https://deno.land/api?unstable=true).

Examples to try:

`d> Deno.version`
`d> let x: string = 'hello world'; x`
